### PR TITLE
Relock jupyter-server-mathjax dependencies

### DIFF
--- a/NODEJS_FOR_LOCK
+++ b/NODEJS_FOR_LOCK
@@ -1,0 +1,10 @@
+The version of nodejs installed to build the last iteration of the package-lock.json file was:
+v14.17.3
+
+Use nvm to install:
+$ nvm install v14.17.3
+
+Also, to ensure that we end up with consistent results across systems
+$ rm -rf node_modules
+$ rm package-lock.json
+$ npm install

--- a/jupyter-server-mathjax/package-lock.json
+++ b/jupyter-server-mathjax/package-lock.json
@@ -51,9 +51,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -65,9 +65,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
     "inflight": {


### PR DESCRIPTION
Also include a NODEJS_FOR_LOCK readme with instructions on how
to relock consistently across build systems.

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
