### PR TITLE
Update version of graceful-fs in gateway/package.json

### DIFF
--- a/gateway/package-lock.json
+++ b/gateway/package-lock.json
@@ -628,9 +628,9 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ=="
     },
     "has-value": {
       "version": "1.0.0",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "express": "4.16.4",
-    "graceful-fs": "4.2.8",
+    "graceful-fs": "4.2.9",
     "http-proxy-middleware": "0.19.1",
     "morgan": "1.9.1",
     "winston": "3.2.0"


### PR DESCRIPTION
This dependency is indirect, so the version has to be listed
in the package.json.  It is possible for the z version to
be out of date if the indirect reference updates (downstream
build will fail).
