### PR TITLE
Previous commit accidentally left notebook package explicit

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,6 @@ jupyter_server==1.4.1
 jupyter_packaging~=0.9
 jupyterlab_server==2.3.0
 nbclassic==0.2.6
-notebook==6.4.1
 ipython==7.16.1
 ipykernel==5.5.5
 cryptography==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -748,7 +748,6 @@ notebook==6.4.1 \
     --hash=sha256:2a67037730e2b2991f5d684ecb07255bbb191f49234888e71e1fabf8e50679a6 \
     --hash=sha256:5d999285fd449898c4dfa0b7880dd881f317c653eb221e8d51d0b5400751ce35
     # via
-    #   -r requirements.in
     #   jupyter-contrib-core
     #   jupyter-contrib-nbextensions
     #   jupyter-kernel-gateway


### PR DESCRIPTION
The goal was to remove the explicit notebook version from requireements.in
to allow jupyterlab to control the version.

(previous commit bfeef0ca7ca3cbef43bf237ca504abc838ca4af1)

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2162
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
