### PR TITLE
Update CPaaS npm dependencies

### DIFF
--- a/jupyter-server-mathjax/package-lock.json
+++ b/jupyter-server-mathjax/package-lock.json
@@ -51,15 +51,15 @@
       "dev": true
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }


### PR DESCRIPTION
Fix this error in CPaaS:

```
atomic_reactor.plugins.imagebuilder - INFO -   npm ERR! code E404
atomic_reactor.plugins.imagebuilder - INFO -   npm ERR! 404 Remote Manually Blocked - GET https://cachito-nexus.engineering.redhat.com/repository/cachito-npm-314253/glob/-/glob-7.2.3.tgz
atomic_reactor.plugins.imagebuilder - INFO -   npm ERR! 404
atomic_reactor.plugins.imagebuilder - INFO -   npm ERR! 404  'glob@^7.1.3' is not in the npm registry.
```
